### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ See [development.md](/docs/development.md).
 
 ## Reading step results
 
+Print the available attributes of context:
+
+```yaml
+- name: View context attributes
+  uses: actions/github-script@0.9.0
+  with:
+    script: console.log(context)
+``` 
+
 The return value of the script will be in the step's outputs under the
 "result" key.
 


### PR DESCRIPTION
Add example of using console.log to display attributes of object context

I spent a couple hrs yesterday trying to track down exactly what was in the object context other than what was shown in examples but could never correlate it directly to the github context listed in [github action contexts](https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions).  This is rather simple but may help someone in the future.